### PR TITLE
Remove usage of strings

### DIFF
--- a/Assets/Scenes/level_1.unity
+++ b/Assets/Scenes/level_1.unity
@@ -1143,6 +1143,36 @@ PrefabInstance:
       propertyPath: levelProgress
       value: 
       objectReference: {fileID: 705208876}
+    - target: {fileID: 2098506098052825356, guid: 81ccdd14908c7d545a6b5843eb059e6d,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2098506098052825356, guid: 81ccdd14908c7d545a6b5843eb059e6d,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2098506098052825356, guid: 81ccdd14908c7d545a6b5843eb059e6d,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2098506098052825356, guid: 81ccdd14908c7d545a6b5843eb059e6d,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2098506098052825356, guid: 81ccdd14908c7d545a6b5843eb059e6d,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2098506098052825356, guid: 81ccdd14908c7d545a6b5843eb059e6d,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 2098506098052825357, guid: 81ccdd14908c7d545a6b5843eb059e6d,
         type: 3}
       propertyPath: m_havePropertiesChanged
@@ -1152,6 +1182,36 @@ PrefabInstance:
         type: 3}
       propertyPath: m_isInputParsingRequired
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2098506098186302001, guid: 81ccdd14908c7d545a6b5843eb059e6d,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2098506098186302001, guid: 81ccdd14908c7d545a6b5843eb059e6d,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2098506098186302001, guid: 81ccdd14908c7d545a6b5843eb059e6d,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2098506098186302001, guid: 81ccdd14908c7d545a6b5843eb059e6d,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2098506098186302001, guid: 81ccdd14908c7d545a6b5843eb059e6d,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2098506098186302001, guid: 81ccdd14908c7d545a6b5843eb059e6d,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2098506098186302014, guid: 81ccdd14908c7d545a6b5843eb059e6d,
         type: 3}
@@ -1163,6 +1223,36 @@ PrefabInstance:
       propertyPath: m_isInputParsingRequired
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 2098506098219873189, guid: 81ccdd14908c7d545a6b5843eb059e6d,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2098506098219873189, guid: 81ccdd14908c7d545a6b5843eb059e6d,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2098506098219873189, guid: 81ccdd14908c7d545a6b5843eb059e6d,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2098506098219873189, guid: 81ccdd14908c7d545a6b5843eb059e6d,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2098506098219873189, guid: 81ccdd14908c7d545a6b5843eb059e6d,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2098506098219873189, guid: 81ccdd14908c7d545a6b5843eb059e6d,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 2098506098219873186, guid: 81ccdd14908c7d545a6b5843eb059e6d,
         type: 3}
       propertyPath: m_havePropertiesChanged
@@ -1172,6 +1262,36 @@ PrefabInstance:
         type: 3}
       propertyPath: m_isInputParsingRequired
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2098506099270519833, guid: 81ccdd14908c7d545a6b5843eb059e6d,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2098506099270519833, guid: 81ccdd14908c7d545a6b5843eb059e6d,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2098506099270519833, guid: 81ccdd14908c7d545a6b5843eb059e6d,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2098506099270519833, guid: 81ccdd14908c7d545a6b5843eb059e6d,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2098506099270519833, guid: 81ccdd14908c7d545a6b5843eb059e6d,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2098506099270519833, guid: 81ccdd14908c7d545a6b5843eb059e6d,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2098506099270519814, guid: 81ccdd14908c7d545a6b5843eb059e6d,
         type: 3}
@@ -1183,6 +1303,36 @@ PrefabInstance:
       propertyPath: m_isInputParsingRequired
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 2098506098644313184, guid: 81ccdd14908c7d545a6b5843eb059e6d,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2098506098644313184, guid: 81ccdd14908c7d545a6b5843eb059e6d,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2098506098644313184, guid: 81ccdd14908c7d545a6b5843eb059e6d,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2098506098644313184, guid: 81ccdd14908c7d545a6b5843eb059e6d,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2098506098644313184, guid: 81ccdd14908c7d545a6b5843eb059e6d,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2098506098644313184, guid: 81ccdd14908c7d545a6b5843eb059e6d,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 2098506098644313185, guid: 81ccdd14908c7d545a6b5843eb059e6d,
         type: 3}
       propertyPath: m_havePropertiesChanged
@@ -1192,6 +1342,36 @@ PrefabInstance:
         type: 3}
       propertyPath: m_isInputParsingRequired
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2098506098064501571, guid: 81ccdd14908c7d545a6b5843eb059e6d,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2098506098064501571, guid: 81ccdd14908c7d545a6b5843eb059e6d,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2098506098064501571, guid: 81ccdd14908c7d545a6b5843eb059e6d,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2098506098064501571, guid: 81ccdd14908c7d545a6b5843eb059e6d,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2098506098064501571, guid: 81ccdd14908c7d545a6b5843eb059e6d,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2098506098064501571, guid: 81ccdd14908c7d545a6b5843eb059e6d,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2098506098064501568, guid: 81ccdd14908c7d545a6b5843eb059e6d,
         type: 3}
@@ -1203,6 +1383,36 @@ PrefabInstance:
       propertyPath: m_isInputParsingRequired
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 2098506099721310081, guid: 81ccdd14908c7d545a6b5843eb059e6d,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2098506099721310081, guid: 81ccdd14908c7d545a6b5843eb059e6d,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2098506099721310081, guid: 81ccdd14908c7d545a6b5843eb059e6d,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2098506099721310081, guid: 81ccdd14908c7d545a6b5843eb059e6d,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2098506099721310081, guid: 81ccdd14908c7d545a6b5843eb059e6d,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2098506099721310081, guid: 81ccdd14908c7d545a6b5843eb059e6d,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 2098506099721310094, guid: 81ccdd14908c7d545a6b5843eb059e6d,
         type: 3}
       propertyPath: m_havePropertiesChanged
@@ -1212,6 +1422,36 @@ PrefabInstance:
         type: 3}
       propertyPath: m_isInputParsingRequired
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2098506099082389000, guid: 81ccdd14908c7d545a6b5843eb059e6d,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2098506099082389000, guid: 81ccdd14908c7d545a6b5843eb059e6d,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2098506099082389000, guid: 81ccdd14908c7d545a6b5843eb059e6d,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2098506099082389000, guid: 81ccdd14908c7d545a6b5843eb059e6d,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2098506099082389000, guid: 81ccdd14908c7d545a6b5843eb059e6d,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2098506099082389000, guid: 81ccdd14908c7d545a6b5843eb059e6d,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2098506099082389001, guid: 81ccdd14908c7d545a6b5843eb059e6d,
         type: 3}
@@ -1223,6 +1463,36 @@ PrefabInstance:
       propertyPath: m_isInputParsingRequired
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 2098506099992606765, guid: 81ccdd14908c7d545a6b5843eb059e6d,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2098506099992606765, guid: 81ccdd14908c7d545a6b5843eb059e6d,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2098506099992606765, guid: 81ccdd14908c7d545a6b5843eb059e6d,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2098506099992606765, guid: 81ccdd14908c7d545a6b5843eb059e6d,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2098506099992606765, guid: 81ccdd14908c7d545a6b5843eb059e6d,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2098506099992606765, guid: 81ccdd14908c7d545a6b5843eb059e6d,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 2098506099992606762, guid: 81ccdd14908c7d545a6b5843eb059e6d,
         type: 3}
       propertyPath: m_havePropertiesChanged
@@ -1232,6 +1502,36 @@ PrefabInstance:
         type: 3}
       propertyPath: m_isInputParsingRequired
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2098506099733472189, guid: 81ccdd14908c7d545a6b5843eb059e6d,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2098506099733472189, guid: 81ccdd14908c7d545a6b5843eb059e6d,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2098506099733472189, guid: 81ccdd14908c7d545a6b5843eb059e6d,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2098506099733472189, guid: 81ccdd14908c7d545a6b5843eb059e6d,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2098506099733472189, guid: 81ccdd14908c7d545a6b5843eb059e6d,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2098506099733472189, guid: 81ccdd14908c7d545a6b5843eb059e6d,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2098506099733472186, guid: 81ccdd14908c7d545a6b5843eb059e6d,
         type: 3}

--- a/Assets/Scripts/Behaviors/Despawnable.cs
+++ b/Assets/Scripts/Behaviors/Despawnable.cs
@@ -14,20 +14,17 @@ public class Despawnable : MonoBehaviour {
     /// <summary>
     /// Represents all objects that have been happily despawned.
     /// </summary>
-    private static Dictionary<string, int> happyDespawnCount = new Dictionary<string, int>();
+    private static Dictionary<GameObject, int> happyDespawnCount = new Dictionary<GameObject, int>();
     /// <summary>
     /// Represents all objects that have been angerly despawned.
     /// </summary>
-    private static Dictionary<string, int> angryDespawnCount = new Dictionary<string, int>();
+    private static Dictionary<GameObject, int> angryDespawnCount = new Dictionary<GameObject, int>();
 
-    private void IncrementCount(Dictionary<string, int> dictionary) {
+    private void IncrementCount(Dictionary<GameObject, int> dictionary) {
         int currentCount;
-        string originalPrefabName = SimplePool.GetOriginalPrefabName(this.gameObject);
-
-        // print("Despawner IncrementCount originalPrefabName " + originalPrefabName);
-
-        dictionary.TryGetValue(originalPrefabName, out currentCount);
-        dictionary[originalPrefabName] = currentCount + 1;
+        
+        dictionary.TryGetValue(this.gameObject, out currentCount);
+        dictionary[this.gameObject] = currentCount + 1;
     }
 
     public void HappilyDespawn() {

--- a/Assets/Scripts/Components/DynamicButtonCreator.cs
+++ b/Assets/Scripts/Components/DynamicButtonCreator.cs
@@ -26,7 +26,7 @@ public class DynamicButtonCreator : MonoBehaviour {
     [Tooltip("We will remove this string from the end of the file to make a dynamic button text.")]
     private string fileEndingToRemove = ".prefab";
     private bool activateChildrenButtons = false;
-    private List<string> playerBuildingPrefabs = new List<string>();
+    private List<BuildingData> allowedPlayerBuildings = new List<BuildingData>();
     private List<GameObject> childButtons = new List<GameObject>();
     private float buttonHeight = 30.0f;
     private BuildingPlacer buildingPlacer;
@@ -35,28 +35,19 @@ public class DynamicButtonCreator : MonoBehaviour {
     private CurrentLevel currentLevel;
 
     private void fetchPlayerBuildingPrefabs() {
-        UnityEngine.Object[] buildings = Resources.LoadAll(filePath);
-   
-        foreach (UnityEngine.Object o in buildings) {
-            if (!o.name.EndsWith(this.fileEndingsToIgnore)) {
-                this.playerBuildingPrefabs.Add(o.name.Split(new[] { this.fileEndingToRemove }, StringSplitOptions.None)[0]);
-            }
-        }
-
-        // Disables any buildings dictated by level
         if (this.currentLevel.getLevelData != null) {
-            foreach (GameObject gameObject in this.currentLevel.getLevelData.BannedPlayerBuildings) {
-                this.playerBuildingPrefabs.Remove(gameObject.transform.name);
+            foreach (BuildingData buildingData in this.currentLevel.getLevelData.AllowedPlayerBuildings) {
+                this.allowedPlayerBuildings.Add(buildingData);
             }
         }
     }
 
     private void addPlayerBuildingPrefabButtonsDeactivated() {
-        for (int i = 0; i < this.playerBuildingPrefabs.Count; i++) {
+        for (int i = 0; i < this.allowedPlayerBuildings.Count; i++) {
             GameObject newButton = Instantiate(this.buttonPrefab) as GameObject;
             newButton.transform.SetParent(this.parentButton.transform, false);
 
-            newButton.GetComponentInChildren<Text>().text = this.playerBuildingPrefabs[i];
+            newButton.GetComponentInChildren<Text>().text = this.allowedPlayerBuildings[i].Name;
             newButton.transform.SetParent(this.parentButton.transform, false);
             int iOneBasedForMultiplication = i + 1;
             newButton.transform.position = new Vector3(
@@ -88,8 +79,6 @@ public class DynamicButtonCreator : MonoBehaviour {
     }
 
     void BuildABuildingButtonClicked(int buttonNo) {
-        string filePath = "Prefabs/Player Buildings/" + this.playerBuildingPrefabs[buttonNo];
-        GameObject buildingToCreate = (GameObject)Resources.Load(filePath);
-        this.buildingPlacer.buildingToCreate = buildingToCreate;
+        this.buildingPlacer.buildingToCreate = this.allowedPlayerBuildings[buttonNo].Prefab;
     }
 }

--- a/Assets/Scripts/Components/DynamicButtonCreator.cs
+++ b/Assets/Scripts/Components/DynamicButtonCreator.cs
@@ -16,15 +16,6 @@ public class DynamicButtonCreator : MonoBehaviour {
     [SerializeField]
     [Tooltip("Button to base all children buttons off of.")]
     private GameObject parentButton;
-    [SerializeField]
-    [Tooltip("Relative folder to look at for content.")]
-    private string filePath;
-    [SerializeField]
-    [Tooltip("We won't build dynamic buttons for files that end in this string.")]
-    private string fileEndingsToIgnore = ".meta";
-    [SerializeField]
-    [Tooltip("We will remove this string from the end of the file to make a dynamic button text.")]
-    private string fileEndingToRemove = ".prefab";
     private bool activateChildrenButtons = false;
     private List<BuildingData> allowedPlayerBuildings = new List<BuildingData>();
     private List<GameObject> childButtons = new List<GameObject>();

--- a/Assets/Scripts/Components/LevelProgress.cs
+++ b/Assets/Scripts/Components/LevelProgress.cs
@@ -19,20 +19,20 @@ public class LevelProgress : MonoBehaviour {
     [SerializeField]
     [Tooltip("Current Level component, that stores what we're playing")]
     private CurrentLevel currentLevel;
-    public Dictionary<string, int> initialGoodItems = new Dictionary<string, int>();
-    public Dictionary<string, int> initialBadItems = new Dictionary<string, int>();
-    public Dictionary<string, int> liveGoodItems = new Dictionary<string, int>();
-    public Dictionary<string, int> liveBadItems = new Dictionary<string, int>();
+    public Dictionary<ItemData, int> initialGoodItems = new Dictionary<ItemData, int>();
+    public Dictionary<ItemData, int> initialBadItems = new Dictionary<ItemData, int>();
+    public Dictionary<ItemData, int> liveGoodItems = new Dictionary<ItemData, int>();
+    public Dictionary<ItemData, int> liveBadItems = new Dictionary<ItemData, int>();
 
     void InitializeLiveData() {
         this.initialGoodItems = LevelInformation.ItemListToDictionary(this.currentLevel.getLevelData.GoodItems);
         this.initialBadItems = LevelInformation.ItemListToDictionary(this.currentLevel.getLevelData.BadItems);
 
-        foreach (KeyValuePair<string, int> entry in this.initialGoodItems) {
+        foreach (KeyValuePair<ItemData, int> entry in this.initialGoodItems) {
             this.liveGoodItems.Add(entry.Key, 0);
         }
 
-        foreach (KeyValuePair<string, int> entry in this.initialBadItems) {
+        foreach (KeyValuePair<ItemData, int> entry in this.initialBadItems) {
             this.liveBadItems.Add(entry.Key, 0);
         }
     }
@@ -56,7 +56,7 @@ public class LevelProgress : MonoBehaviour {
     }
 
     public bool HasWonLevel() {
-        foreach (KeyValuePair<string, int> entry in this.initialGoodItems) {
+        foreach (KeyValuePair<ItemData, int> entry in this.initialGoodItems) {
             if (this.liveGoodItems[entry.Key] < entry.Value) {
                 return false;
             }
@@ -67,7 +67,7 @@ public class LevelProgress : MonoBehaviour {
 
     public bool HasLostLevel() {
         if (this.initialBadItems.Count > 0) {
-            foreach (KeyValuePair<string, int> entry in this.initialBadItems) {
+            foreach (KeyValuePair<ItemData, int> entry in this.initialBadItems) {
                 if (this.liveBadItems[entry.Key] < entry.Value) {
                     return false;
                 }
@@ -80,13 +80,16 @@ public class LevelProgress : MonoBehaviour {
     }
 
     public void HandleDespawn(GameObject gameObjectAboutToBeDespawned, Despawnable.TypeOfDespawn typeOfDespawn) {
-        string nameOfItemDespawned = gameObjectAboutToBeDespawned.transform.name.Split(' ')[0];
-        // Debug.Log("HandleDespawn of " + nameOfItemDespawned);
+        foreach (KeyValuePair<ItemData, int> entry in this.liveGoodItems) {
+            if (gameObjectAboutToBeDespawned.GetType() == entry.Key.Prefab.GetType()) {
+                this.liveGoodItems[entry.Key] += 1;
+            }
+        }
 
-        if (typeOfDespawn == Despawnable.TypeOfDespawn.Happily) {
-            this.liveGoodItems[nameOfItemDespawned] += 1;
-        } else if (typeOfDespawn == Despawnable.TypeOfDespawn.Angrily) {
-            this.liveBadItems[nameOfItemDespawned] += 1;
+        foreach (KeyValuePair<ItemData, int> entry in this.liveBadItems) {
+            if (gameObjectAboutToBeDespawned.GetType() == entry.Key.Prefab.GetType()) {
+                this.liveBadItems[entry.Key] += 1;
+            }
         }
 
         if (this.HasWonLevel()) {

--- a/Assets/Scripts/Components/LevelProgress.cs
+++ b/Assets/Scripts/Components/LevelProgress.cs
@@ -80,15 +80,20 @@ public class LevelProgress : MonoBehaviour {
     }
 
     public void HandleDespawn(GameObject gameObjectAboutToBeDespawned, Despawnable.TypeOfDespawn typeOfDespawn) {
-        foreach (KeyValuePair<ItemData, int> entry in this.liveGoodItems) {
-            if (gameObjectAboutToBeDespawned.GetType() == entry.Key.Prefab.GetType()) {
-                this.liveGoodItems[entry.Key] += 1;
+        // A weird way to iterate over a dictionary and make changes, to protect ourselves from an out of sync error
+        // See: https://stackoverflow.com/a/1070795/1983957
+        List<ItemData> keysWhoseValueMayBeModified = new List<ItemData>(this.liveGoodItems.Keys);
+
+        foreach (ItemData itemData in keysWhoseValueMayBeModified) {
+            if (gameObjectAboutToBeDespawned.GetType() == itemData.Prefab.GetType()) {
+                this.liveGoodItems[itemData] += 1;
             }
         }
 
-        foreach (KeyValuePair<ItemData, int> entry in this.liveBadItems) {
-            if (gameObjectAboutToBeDespawned.GetType() == entry.Key.Prefab.GetType()) {
-                this.liveBadItems[entry.Key] += 1;
+        keysWhoseValueMayBeModified = new List<ItemData>(this.liveBadItems.Keys);
+        foreach (ItemData itemData in keysWhoseValueMayBeModified) {
+            if (gameObjectAboutToBeDespawned.GetType() == itemData.Prefab.GetType()) {
+                this.liveBadItems[itemData] += 1;
             }
         }
 

--- a/Assets/Scripts/LevelInformation.cs
+++ b/Assets/Scripts/LevelInformation.cs
@@ -16,22 +16,21 @@ public class LevelInformation : MonoBehaviour {
     [Tooltip("Reference to progress in game.")]
     private LevelProgress levelProgress;
 
-    public string ItemListToString(List<LevelData.Item> items) {
+    public string ItemListToString(List<LevelData.RequiredItemData> requiredItemData) {
         string s = "";
 
-        foreach (LevelData.Item item in items) {
-            s += item.amount + " " + item.name + "\n";
+        foreach (LevelData.RequiredItemData item in requiredItemData) {
+            s += item.amount + " " + item.itemData.name + "\n";
         }
 
         return s;
     }
 
-    static public Dictionary<string, int> ItemListToDictionary(List<LevelData.Item> items) {
-        Dictionary<string, int> itemData = new Dictionary<string, int>();
+    static public Dictionary<ItemData, int> ItemListToDictionary(List<LevelData.RequiredItemData> items) {
+        Dictionary<ItemData, int> itemData = new Dictionary<ItemData, int>();
 
-
-        foreach (LevelData.Item item in items) {
-            itemData.Add(item.name, item.amount);
+        foreach (LevelData.RequiredItemData requiredItemData in items) {
+            itemData.Add(requiredItemData.itemData, requiredItemData.amount);
         }
 
         return itemData;
@@ -49,13 +48,13 @@ public class LevelInformation : MonoBehaviour {
 
         goodItems.text = "Pass Level: ";
 
-        foreach(KeyValuePair<string, int> entry in this.levelProgress.initialGoodItems) {
+        foreach(KeyValuePair<ItemData, int> entry in this.levelProgress.initialGoodItems) {
             goodItems.text += "\n\t" + this.levelProgress.liveGoodItems[entry.Key] + " of " + this.levelProgress.initialGoodItems[entry.Key] + " " + entry.Key;
         }
 
         badItems.text = "Fail Level: ";
 
-        foreach (KeyValuePair<string, int> entry in this.levelProgress.initialBadItems) {
+        foreach (KeyValuePair<ItemData, int> entry in this.levelProgress.initialBadItems) {
             badItems.text += "\n\t" + this.levelProgress.liveBadItems[entry.Key] + " of " + this.levelProgress.initialBadItems[entry.Key] + " " + entry.Key;
         }
     }

--- a/Assets/Scripts/ScriptableObjects/BuildingData.cs
+++ b/Assets/Scripts/ScriptableObjects/BuildingData.cs
@@ -1,0 +1,45 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+/// <summary>
+/// Represents all the data for a building that can be played by a player or by the level designer.
+/// </summary>
+[CreateAssetMenu(fileName = "New BuildingData", menuName = "BuildingData", order = 51)]
+public class BuildingData : ScriptableObject {
+    [SerializeField]
+    [Tooltip("The name of this building")]
+    private string name;
+
+    [SerializeField]
+    [Tooltip("The tooltip text that will be displayed when highlighting this building to place in the build menu.")]
+    private string toolTip;
+
+    [SerializeField]
+    [Tooltip("The building that will be placed")]
+    private GameObject prefab;
+
+
+
+    public string Name {
+        get {
+            return this.name;
+        }
+    }
+
+    public string ToolTip {
+        get {
+            return this.toolTip;
+        }
+    }
+
+    public GameObject Prefab {
+        get {
+            return this.prefab;
+        }
+    }
+
+    public override string ToString() {
+        return this.name;
+    }
+}

--- a/Assets/Scripts/ScriptableObjects/BuildingData.cs
+++ b/Assets/Scripts/ScriptableObjects/BuildingData.cs
@@ -19,8 +19,6 @@ public class BuildingData : ScriptableObject {
     [Tooltip("The building that will be placed")]
     private GameObject prefab;
 
-
-
     public string Name {
         get {
             return this.name;

--- a/Assets/Scripts/ScriptableObjects/BuildingData.cs.meta
+++ b/Assets/Scripts/ScriptableObjects/BuildingData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 29f02abab126c3e4a850cecbbf5e2316
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/ScriptableObjects/Items.meta
+++ b/Assets/Scripts/ScriptableObjects/Items.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9e62eeff6553ab14d936fdfc2f1e0248
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/ScriptableObjects/Items/Box.asset
+++ b/Assets/Scripts/ScriptableObjects/Items/Box.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d121f19255811d64694b928356af4e1d, type: 3}
+  m_Name: Box
+  m_EditorClassIdentifier: 
+  name: Box
+  prefab: {fileID: 1524839502340373190, guid: 8f7ddd0ee6ef340a2820c4e175c5922f, type: 3}

--- a/Assets/Scripts/ScriptableObjects/Items/Box.asset.meta
+++ b/Assets/Scripts/ScriptableObjects/Items/Box.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f3a7fb1d2088b734d9440a0dff42890a
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/ScriptableObjects/Items/ItemData.cs
+++ b/Assets/Scripts/ScriptableObjects/Items/ItemData.cs
@@ -1,0 +1,33 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+/// <summary>
+/// Represents an Item that may be used in game.
+/// </summary>
+[CreateAssetMenu(fileName = "New ItemData", menuName = "ItemData", order = 51)]
+public class ItemData : ScriptableObject {
+    [SerializeField]
+    [Tooltip("The name of this Item")]
+    private string name;
+
+    [SerializeField]
+    [Tooltip("The item that will be placed")]
+    private GameObject prefab;
+
+    public string Name {
+        get {
+            return this.name;
+        }
+    }
+
+    public GameObject Prefab {
+        get {
+            return this.prefab;
+        }
+    }
+
+    public override string ToString() {
+        return this.name;
+    }
+}

--- a/Assets/Scripts/ScriptableObjects/Items/ItemData.cs.meta
+++ b/Assets/Scripts/ScriptableObjects/Items/ItemData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d121f19255811d64694b928356af4e1d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/ScriptableObjects/Items/Log.asset
+++ b/Assets/Scripts/ScriptableObjects/Items/Log.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d121f19255811d64694b928356af4e1d, type: 3}
+  m_Name: Log
+  m_EditorClassIdentifier: 
+  name: Log
+  prefab: {fileID: 6541329804399880305, guid: a71b33c85089c1f4882b67122769c38e, type: 3}

--- a/Assets/Scripts/ScriptableObjects/Items/Log.asset.meta
+++ b/Assets/Scripts/ScriptableObjects/Items/Log.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 13a6bfda16c5ce649a0528d3e6743634
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/ScriptableObjects/Items/Plank.asset
+++ b/Assets/Scripts/ScriptableObjects/Items/Plank.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d121f19255811d64694b928356af4e1d, type: 3}
+  m_Name: Plank
+  m_EditorClassIdentifier: 
+  name: Plank
+  prefab: {fileID: 2346481679376236214, guid: c603ba0c35c8702478b804b606ee7f2c, type: 3}

--- a/Assets/Scripts/ScriptableObjects/Items/Plank.asset.meta
+++ b/Assets/Scripts/ScriptableObjects/Items/Plank.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 77b8944852314404e9cf1c4580e71cd5
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/ScriptableObjects/Level Design Buildings.meta
+++ b/Assets/Scripts/ScriptableObjects/Level Design Buildings.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8e0767fe7cd525e4da48f6bbb3469ef7
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/ScriptableObjects/Level Design Buildings/BlankObjectSpawner.asset
+++ b/Assets/Scripts/ScriptableObjects/Level Design Buildings/BlankObjectSpawner.asset
@@ -1,0 +1,17 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 29f02abab126c3e4a850cecbbf5e2316, type: 3}
+  m_Name: BlankObjectSpawner
+  m_EditorClassIdentifier: 
+  name: Item Spawner
+  toolTip: Spawns items.
+  prefab: {fileID: 259040751010061624, guid: 769cd7e0403b8cf4d99f21d197a8b0c8, type: 3}

--- a/Assets/Scripts/ScriptableObjects/Level Design Buildings/BlankObjectSpawner.asset.meta
+++ b/Assets/Scripts/ScriptableObjects/Level Design Buildings/BlankObjectSpawner.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3b8ba622485a6de40b5db7c795a2a265
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/ScriptableObjects/Level Design Buildings/BoxSpawner.asset
+++ b/Assets/Scripts/ScriptableObjects/Level Design Buildings/BoxSpawner.asset
@@ -1,0 +1,17 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 29f02abab126c3e4a850cecbbf5e2316, type: 3}
+  m_Name: BoxSpawner
+  m_EditorClassIdentifier: 
+  name: Box Spawner
+  toolTip: Spawns boxes.
+  prefab: {fileID: 3033362495798048807, guid: 8ab7515fb9e4de34ebede372cf458285, type: 3}

--- a/Assets/Scripts/ScriptableObjects/Level Design Buildings/BoxSpawner.asset.meta
+++ b/Assets/Scripts/ScriptableObjects/Level Design Buildings/BoxSpawner.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 50d82cec37fa4c14faaf5c0e67110e26
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/ScriptableObjects/Level Design Buildings/ButtonPrefab.asset
+++ b/Assets/Scripts/ScriptableObjects/Level Design Buildings/ButtonPrefab.asset
@@ -1,0 +1,17 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 29f02abab126c3e4a850cecbbf5e2316, type: 3}
+  m_Name: ButtonPrefab
+  m_EditorClassIdentifier: 
+  name: Button
+  toolTip: Button
+  prefab: {fileID: 4701018217650971638, guid: 45e2ef5f9f5134681a7696ca5168ab5e, type: 3}

--- a/Assets/Scripts/ScriptableObjects/Level Design Buildings/ButtonPrefab.asset.meta
+++ b/Assets/Scripts/ScriptableObjects/Level Design Buildings/ButtonPrefab.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0bab0105aa0a7134291a502ab11e2917
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/ScriptableObjects/Level Design Buildings/GoalDespawner.asset
+++ b/Assets/Scripts/ScriptableObjects/Level Design Buildings/GoalDespawner.asset
@@ -1,0 +1,17 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 29f02abab126c3e4a850cecbbf5e2316, type: 3}
+  m_Name: GoalDespawner
+  m_EditorClassIdentifier: 
+  name: Goal
+  toolTip: To win, items should make it to this building.
+  prefab: {fileID: 916184766, guid: 9285182c873613241b7d03b0eae55797, type: 3}

--- a/Assets/Scripts/ScriptableObjects/Level Design Buildings/GoalDespawner.asset.meta
+++ b/Assets/Scripts/ScriptableObjects/Level Design Buildings/GoalDespawner.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a011a173a349ec147960f9c5761615b1
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/ScriptableObjects/Level Design Buildings/LogSpawner.asset
+++ b/Assets/Scripts/ScriptableObjects/Level Design Buildings/LogSpawner.asset
@@ -1,0 +1,17 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 29f02abab126c3e4a850cecbbf5e2316, type: 3}
+  m_Name: LogSpawner
+  m_EditorClassIdentifier: 
+  name: Log Spawner
+  toolTip: Spawns logs.
+  prefab: {fileID: 8718537224321683090, guid: 4b4430118ce51c348bdfb267174766c0, type: 3}

--- a/Assets/Scripts/ScriptableObjects/Level Design Buildings/LogSpawner.asset.meta
+++ b/Assets/Scripts/ScriptableObjects/Level Design Buildings/LogSpawner.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e2754307c429a584fb223f8d71c67d6d
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/ScriptableObjects/Level Design Buildings/TrashDespawner.asset
+++ b/Assets/Scripts/ScriptableObjects/Level Design Buildings/TrashDespawner.asset
@@ -1,0 +1,17 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 29f02abab126c3e4a850cecbbf5e2316, type: 3}
+  m_Name: TrashDespawner
+  m_EditorClassIdentifier: 
+  name: Trash
+  toolTip: To lose, items would touch this.
+  prefab: {fileID: 1685500460, guid: 34493a1adabb54fecbec3465c8c90463, type: 3}

--- a/Assets/Scripts/ScriptableObjects/Level Design Buildings/TrashDespawner.asset.meta
+++ b/Assets/Scripts/ScriptableObjects/Level Design Buildings/TrashDespawner.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 10a87e5492fba3940adbd7eacaa76505
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/ScriptableObjects/Level Design Buildings/Tunnel.asset
+++ b/Assets/Scripts/ScriptableObjects/Level Design Buildings/Tunnel.asset
@@ -1,0 +1,17 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 29f02abab126c3e4a850cecbbf5e2316, type: 3}
+  m_Name: Tunnel
+  m_EditorClassIdentifier: 
+  name: Tunnel
+  toolTip: Items must be smaller to fit under this.
+  prefab: {fileID: 5492048761717354329, guid: 1c15b932807cb4048a26036a88365097, type: 3}

--- a/Assets/Scripts/ScriptableObjects/Level Design Buildings/Tunnel.asset.meta
+++ b/Assets/Scripts/ScriptableObjects/Level Design Buildings/Tunnel.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a5f9cb6713411a14c88da636fb3ce287
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/ScriptableObjects/Levels/LevelData.cs
+++ b/Assets/Scripts/ScriptableObjects/Levels/LevelData.cs
@@ -6,7 +6,7 @@ using System;
 /// <summary>
 /// Represents all the data for a level that can be played by a player.
 /// </summary>
-[CreateAssetMenu(fileName = "New LevelData", menuName = "Level Data", order = 51)]
+[CreateAssetMenu(fileName = "New LevelData", menuName = "LevelData", order = 51)]
 public class LevelData : ScriptableObject {
     [System.Serializable]
     public struct Item {

--- a/Assets/Scripts/ScriptableObjects/Levels/LevelData.cs
+++ b/Assets/Scripts/ScriptableObjects/Levels/LevelData.cs
@@ -9,9 +9,9 @@ using System;
 [CreateAssetMenu(fileName = "New LevelData", menuName = "LevelData", order = 51)]
 public class LevelData : ScriptableObject {
     [System.Serializable]
-    public struct Item {
-        public string name;
-        public int amount; 
+    public struct RequiredItemData {
+        public ItemData itemData;
+        public int amount;
     }
 
     [SerializeField]
@@ -24,10 +24,10 @@ public class LevelData : ScriptableObject {
     // Dictionaries by default. See https://docs.unity3d.com/ScriptReference/SerializeField.html
     [SerializeField]
     [Tooltip("The items needed to win the level.")]
-    private List<Item> goodItems = new List<Item>();
+    private List<RequiredItemData> goodItems = new List<RequiredItemData>();
     [SerializeField]
     [Tooltip("The items needed to lose the level.")]
-    private List<Item> badItems = new List<Item>();
+    private List<RequiredItemData> badItems = new List<RequiredItemData>();
     [SerializeField]
     [Tooltip("Player buildings allowed on this level")]
     private List<BuildingData> allowedPlayerBuildings = new List<BuildingData>();
@@ -44,13 +44,13 @@ public class LevelData : ScriptableObject {
         }
     }
 
-    public List<Item> GoodItems {
+    public List<RequiredItemData> GoodItems {
         get {
             return this.goodItems;
         }
     }
 
-    public List<Item> BadItems {
+    public List<RequiredItemData> BadItems {
         get {
             return this.badItems;
         }

--- a/Assets/Scripts/ScriptableObjects/Levels/LevelData.cs
+++ b/Assets/Scripts/ScriptableObjects/Levels/LevelData.cs
@@ -29,8 +29,8 @@ public class LevelData : ScriptableObject {
     [Tooltip("The items needed to lose the level.")]
     private List<Item> badItems = new List<Item>();
     [SerializeField]
-    [Tooltip("Player buildings not allowed on this level")]
-    private List<GameObject> bannedPlayerBuildings = new List<GameObject>();
+    [Tooltip("Player buildings allowed on this level")]
+    private List<BuildingData> allowedPlayerBuildings = new List<BuildingData>();
 
     public string LevelName {
         get {
@@ -56,9 +56,9 @@ public class LevelData : ScriptableObject {
         }
     }
 
-    public List<GameObject> BannedPlayerBuildings {
+    public List<BuildingData> AllowedPlayerBuildings {
         get {
-            return this.bannedPlayerBuildings;
+            return this.allowedPlayerBuildings;
         }
     }
 

--- a/Assets/Scripts/ScriptableObjects/Levels/Level_1.asset
+++ b/Assets/Scripts/ScriptableObjects/Levels/Level_1.asset
@@ -15,6 +15,7 @@ MonoBehaviour:
   levelName: Level 1
   description: Most basic level, where you only have to move five boxes
   goodItems:
-  - name: Box
+  - itemData: {fileID: 11400000, guid: f3a7fb1d2088b734d9440a0dff42890a, type: 2}
     amount: 5
   badItems: []
+  allowedPlayerBuildings: []

--- a/Assets/Scripts/ScriptableObjects/Levels/Level_1.asset
+++ b/Assets/Scripts/ScriptableObjects/Levels/Level_1.asset
@@ -18,4 +18,5 @@ MonoBehaviour:
   - itemData: {fileID: 11400000, guid: f3a7fb1d2088b734d9440a0dff42890a, type: 2}
     amount: 5
   badItems: []
-  allowedPlayerBuildings: []
+  allowedPlayerBuildings:
+  - {fileID: 11400000, guid: b2e2850eeb4abe34ba6f5ac74f49af2f, type: 2}

--- a/Assets/Scripts/ScriptableObjects/Player Buildings.meta
+++ b/Assets/Scripts/ScriptableObjects/Player Buildings.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a1d487323b1208a489bce4cf90692adf
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/ScriptableObjects/Player Buildings/Arm.asset
+++ b/Assets/Scripts/ScriptableObjects/Player Buildings/Arm.asset
@@ -1,0 +1,17 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 29f02abab126c3e4a850cecbbf5e2316, type: 3}
+  m_Name: Arm
+  m_EditorClassIdentifier: 
+  name: Arm
+  toolTip: Moves objects from one location to another.
+  prefab: {fileID: 9005341524384485718, guid: 3f2eb2b43f5584cddb7df209765305b1, type: 3}

--- a/Assets/Scripts/ScriptableObjects/Player Buildings/Arm.asset.meta
+++ b/Assets/Scripts/ScriptableObjects/Player Buildings/Arm.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4fcb7cc34b75b5243bca858c24c915f8
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/ScriptableObjects/Player Buildings/Cannon.asset
+++ b/Assets/Scripts/ScriptableObjects/Player Buildings/Cannon.asset
@@ -1,0 +1,17 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 29f02abab126c3e4a850cecbbf5e2316, type: 3}
+  m_Name: Cannon
+  m_EditorClassIdentifier: 
+  name: Cannon
+  toolTip: Launchs all objects, that touch its base, forward.
+  prefab: {fileID: 1223070101949860706, guid: 58d58c22bcd4c274192c324136358326, type: 3}

--- a/Assets/Scripts/ScriptableObjects/Player Buildings/Cannon.asset.meta
+++ b/Assets/Scripts/ScriptableObjects/Player Buildings/Cannon.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 873d62ac9487e774685821b01447e930
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/ScriptableObjects/Player Buildings/Conveyor.asset
+++ b/Assets/Scripts/ScriptableObjects/Player Buildings/Conveyor.asset
@@ -1,0 +1,17 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 29f02abab126c3e4a850cecbbf5e2316, type: 3}
+  m_Name: Conveyor
+  m_EditorClassIdentifier: 
+  name: Conveyor
+  toolTip: Moves items along from one side to the other.
+  prefab: {fileID: 5549287773667657060, guid: fd6601a302d87427891d8ec97bcfe443, type: 3}

--- a/Assets/Scripts/ScriptableObjects/Player Buildings/Conveyor.asset.meta
+++ b/Assets/Scripts/ScriptableObjects/Player Buildings/Conveyor.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b2e2850eeb4abe34ba6f5ac74f49af2f
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/ScriptableObjects/Player Buildings/Factory.asset
+++ b/Assets/Scripts/ScriptableObjects/Player Buildings/Factory.asset
@@ -1,0 +1,17 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 29f02abab126c3e4a850cecbbf5e2316, type: 3}
+  m_Name: Factory
+  m_EditorClassIdentifier: 
+  name: Factory
+  toolTip: Takes in raw materials and spit out processed goods.
+  prefab: {fileID: 4849384599738129611, guid: f136024eddfb44afb8142f9955f46318, type: 3}

--- a/Assets/Scripts/ScriptableObjects/Player Buildings/Factory.asset.meta
+++ b/Assets/Scripts/ScriptableObjects/Player Buildings/Factory.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ac859a296c4639644a3eebf18466c5be
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/ScriptableObjects/Player Buildings/Fan.asset
+++ b/Assets/Scripts/ScriptableObjects/Player Buildings/Fan.asset
@@ -1,0 +1,17 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 29f02abab126c3e4a850cecbbf5e2316, type: 3}
+  m_Name: Fan
+  m_EditorClassIdentifier: 
+  name: Fan
+  toolTip: Blows items away.
+  prefab: {fileID: 8192295896923294452, guid: 01b231b4b8bb7404fae1556d2cb1b50f, type: 3}

--- a/Assets/Scripts/ScriptableObjects/Player Buildings/Fan.asset.meta
+++ b/Assets/Scripts/ScriptableObjects/Player Buildings/Fan.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5b3ac481830f8a847b2703c9fb131e50
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/ScriptableObjects/Player Buildings/Grower.asset
+++ b/Assets/Scripts/ScriptableObjects/Player Buildings/Grower.asset
@@ -1,0 +1,17 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 29f02abab126c3e4a850cecbbf5e2316, type: 3}
+  m_Name: Grower
+  m_EditorClassIdentifier: 
+  name: Grower
+  toolTip: Takes in items and spit out the same item but larger.
+  prefab: {fileID: 1169876963969983831, guid: 48884eedbbc8647239a8af0f6bcce26e, type: 3}

--- a/Assets/Scripts/ScriptableObjects/Player Buildings/Grower.asset.meta
+++ b/Assets/Scripts/ScriptableObjects/Player Buildings/Grower.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6289413190bb16e4fb4b0eda0323b77e
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/ScriptableObjects/Player Buildings/Merger.asset
+++ b/Assets/Scripts/ScriptableObjects/Player Buildings/Merger.asset
@@ -1,0 +1,17 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 29f02abab126c3e4a850cecbbf5e2316, type: 3}
+  m_Name: Merger
+  m_EditorClassIdentifier: 
+  name: Merger
+  toolTip: Merges two streams of items into one stream.
+  prefab: {fileID: 1412456094467927389, guid: 5ad22c8611c8f44848d2140bc245350b, type: 3}

--- a/Assets/Scripts/ScriptableObjects/Player Buildings/Merger.asset.meta
+++ b/Assets/Scripts/ScriptableObjects/Player Buildings/Merger.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5e71d1914fe55bf4791f14cd44eeb11a
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/ScriptableObjects/Player Buildings/Shrinker.asset
+++ b/Assets/Scripts/ScriptableObjects/Player Buildings/Shrinker.asset
@@ -1,0 +1,17 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 29f02abab126c3e4a850cecbbf5e2316, type: 3}
+  m_Name: Shrinker
+  m_EditorClassIdentifier: 
+  name: Shrinker
+  toolTip: Takes in items and spit out the same item but larger.
+  prefab: {fileID: 6930375892507161596, guid: 0bb02ce4f864145359ec6231436a830d, type: 3}

--- a/Assets/Scripts/ScriptableObjects/Player Buildings/Shrinker.asset.meta
+++ b/Assets/Scripts/ScriptableObjects/Player Buildings/Shrinker.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 618db43f8642c2945a0d5ccb523df15f
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/ScriptableObjects/Player Buildings/Splitter.asset
+++ b/Assets/Scripts/ScriptableObjects/Player Buildings/Splitter.asset
@@ -1,0 +1,17 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 29f02abab126c3e4a850cecbbf5e2316, type: 3}
+  m_Name: Splitter
+  m_EditorClassIdentifier: 
+  name: Splitter
+  toolTip: Splits one streams of items into two streams.
+  prefab: {fileID: 9101616769191815976, guid: 47fe0510b3dc34f80a15524779898439, type: 3}

--- a/Assets/Scripts/ScriptableObjects/Player Buildings/Splitter.asset.meta
+++ b/Assets/Scripts/ScriptableObjects/Player Buildings/Splitter.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f78027467c205904a99828ff2d2c4860
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/ScriptableObjects/Player Buildings/Trampoline.asset
+++ b/Assets/Scripts/ScriptableObjects/Player Buildings/Trampoline.asset
@@ -1,0 +1,17 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 29f02abab126c3e4a850cecbbf5e2316, type: 3}
+  m_Name: Trampoline
+  m_EditorClassIdentifier: 
+  name: Trampoline
+  toolTip: Bounces items away, conserving momentum and trajectory.
+  prefab: {fileID: 71966166578692465, guid: 644fe8687480748c3a5a041291a038fb, type: 3}

--- a/Assets/Scripts/ScriptableObjects/Player Buildings/Trampoline.asset.meta
+++ b/Assets/Scripts/ScriptableObjects/Player Buildings/Trampoline.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f73eead49f6e7d042af7aedda23d67e8
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/ScriptableObjects/Player Buildings/Wall.asset
+++ b/Assets/Scripts/ScriptableObjects/Player Buildings/Wall.asset
@@ -1,0 +1,17 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 29f02abab126c3e4a850cecbbf5e2316, type: 3}
+  m_Name: Wall
+  m_EditorClassIdentifier: 
+  name: Wall
+  toolTip: Stops items from passing through.
+  prefab: {fileID: 3212013727448065394, guid: 91bfd130a140c4767a81f49ffd371b45, type: 3}

--- a/Assets/Scripts/ScriptableObjects/Player Buildings/Wall.asset.meta
+++ b/Assets/Scripts/ScriptableObjects/Player Buildings/Wall.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4f28b6cf09a2268499468baa807da4b4
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/grehg factory/Models/Consumer.meta
+++ b/Assets/grehg factory/Models/Consumer.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 67c8eb37b1b4c9f4491ede7f83004d74
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/grehg factory/Models/Conveyor.meta
+++ b/Assets/grehg factory/Models/Conveyor.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 66b3dcfcc9499cb4c86816bf63d53fac
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 


### PR DESCRIPTION
Using ScriptableObjects or GameObjects. Now we're less reliant on Strings, like the names of our files, classes or even the paths. So I can refactor names and move files and not break my code.

Less fragile!